### PR TITLE
Issue #36 fix null comparisons

### DIFF
--- a/src/main/java/org/testmonkeys/jentitytest/comparison/entity/ChildEntityComparator.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/entity/ChildEntityComparator.java
@@ -3,7 +3,8 @@ package org.testmonkeys.jentitytest.comparison.entity;
 import org.testmonkeys.jentitytest.comparison.ComparisonContext;
 import org.testmonkeys.jentitytest.comparison.MultiResultComparator;
 import org.testmonkeys.jentitytest.comparison.result.ComparisonResult;
-import org.testmonkeys.jentitytest.comparison.result.FailedComparisonResult;
+import org.testmonkeys.jentitytest.comparison.util.NullComparison;
+import org.testmonkeys.jentitytest.comparison.util.NullComparisonResult;
 import org.testmonkeys.jentitytest.framework.JEntityTestException;
 
 import java.beans.PropertyDescriptor;
@@ -14,6 +15,7 @@ import java.util.List;
 
 public class ChildEntityComparator extends MultiResultComparator {
 
+    private final NullComparison nullComparisonHelper = new NullComparison();
     private List<ComparisonResult> comparisonResults;
 
     public ChildEntityComparator() {
@@ -23,15 +25,11 @@ public class ChildEntityComparator extends MultiResultComparator {
     @Override
     protected List<ComparisonResult> computeComparison(PropertyDescriptor property, Object actualValue, Object expectedValue, ComparisonContext context) throws JEntityTestException {
 
-        if (actualValue == null && expectedValue == null)
-            return new ArrayList<>();
-        if (actualValue != null && expectedValue == null || actualValue == null) {
-            List<ComparisonResult> results = new ArrayList<>();
-            ComparisonResult result = new FailedComparisonResult(context,
-                    actualValue == null ? "null" : "not null",
-                    expectedValue == null ? "null" : "not null");
-            results.add(result);
-            return results;
+        NullComparisonResult nullComparisonResult = nullComparisonHelper.compareOnNulls(actualValue, expectedValue, context);
+        if (!nullComparisonResult.isPassed() || nullComparisonResult.isStopComparison()) {
+            List<ComparisonResult> comparisonResults = new ArrayList<>();
+            comparisonResults.add(nullComparisonResult);
+            return comparisonResults;
         }
 
 

--- a/src/main/java/org/testmonkeys/jentitytest/comparison/entity/ChildEntityComparator.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/entity/ChildEntityComparator.java
@@ -3,7 +3,7 @@ package org.testmonkeys.jentitytest.comparison.entity;
 import org.testmonkeys.jentitytest.comparison.ComparisonContext;
 import org.testmonkeys.jentitytest.comparison.MultiResultComparator;
 import org.testmonkeys.jentitytest.comparison.result.ComparisonResult;
-import org.testmonkeys.jentitytest.comparison.util.NullComparison;
+import org.testmonkeys.jentitytest.comparison.util.NullComparator;
 import org.testmonkeys.jentitytest.comparison.util.NullComparisonResult;
 import org.testmonkeys.jentitytest.framework.JEntityTestException;
 
@@ -15,7 +15,7 @@ import java.util.List;
 
 public class ChildEntityComparator extends MultiResultComparator {
 
-    private final NullComparison nullComparisonHelper = new NullComparison();
+    private final NullComparator nullComparatorHelper = new NullComparator();
     private List<ComparisonResult> comparisonResults;
 
     public ChildEntityComparator() {
@@ -25,8 +25,8 @@ public class ChildEntityComparator extends MultiResultComparator {
     @Override
     protected List<ComparisonResult> computeComparison(PropertyDescriptor property, Object actualValue, Object expectedValue, ComparisonContext context) throws JEntityTestException {
 
-        NullComparisonResult nullComparisonResult = nullComparisonHelper.compareOnNulls(actualValue, expectedValue, context);
-        if (!nullComparisonResult.isPassed() || nullComparisonResult.isStopComparison()) {
+        NullComparisonResult nullComparisonResult = nullComparatorHelper.compareOnNulls(actualValue, expectedValue, context);
+        if (!nullComparisonResult.isPassed() || nullComparisonResult.stopComparison()) {
             List<ComparisonResult> comparisonResults = new ArrayList<>();
             comparisonResults.add(nullComparisonResult);
             return comparisonResults;

--- a/src/main/java/org/testmonkeys/jentitytest/comparison/entity/EntityComparator.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/entity/EntityComparator.java
@@ -5,7 +5,7 @@ import org.testmonkeys.jentitytest.comparison.Comparator;
 import org.testmonkeys.jentitytest.comparison.ComparisonContext;
 import org.testmonkeys.jentitytest.comparison.ComparisonModel;
 import org.testmonkeys.jentitytest.comparison.result.ComparisonResult;
-import org.testmonkeys.jentitytest.comparison.util.NullComparison;
+import org.testmonkeys.jentitytest.comparison.util.NullComparator;
 import org.testmonkeys.jentitytest.comparison.util.NullComparisonResult;
 import org.testmonkeys.jentitytest.framework.JEntityTestException;
 
@@ -17,7 +17,7 @@ import java.util.List;
 public class EntityComparator {
 
     private final EntityComparisonDictionary comparisonDictionary = EntityComparisonDictionary.getInstance();
-    private final NullComparison nullComparisonHelper = new NullComparison();
+    private final NullComparator nullComparatorHelper = new NullComparator();
 
     public List<ComparisonResult> compare(Object actual, Object expected) throws JEntityTestException {
 
@@ -32,8 +32,8 @@ public class EntityComparator {
             context.setActualObj(actual);
         }
 
-        NullComparisonResult nullComparisonResult = nullComparisonHelper.compareOnNulls(actual, expected, context);
-        if (!nullComparisonResult.isPassed() || nullComparisonResult.isStopComparison()) {
+        NullComparisonResult nullComparisonResult = nullComparatorHelper.compareOnNulls(actual, expected, context);
+        if (!nullComparisonResult.isPassed() || nullComparisonResult.stopComparison()) {
             comparisonResults.add(nullComparisonResult);
             return comparisonResults;
         }

--- a/src/main/java/org/testmonkeys/jentitytest/comparison/property/DateTimeComparator.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/property/DateTimeComparator.java
@@ -3,6 +3,8 @@ package org.testmonkeys.jentitytest.comparison.property;
 import org.testmonkeys.jentitytest.comparison.ComparisonContext;
 import org.testmonkeys.jentitytest.comparison.SingleResultComparator;
 import org.testmonkeys.jentitytest.comparison.result.ComparisonResult;
+import org.testmonkeys.jentitytest.comparison.util.NullComparison;
+import org.testmonkeys.jentitytest.comparison.util.NullComparisonResult;
 import org.testmonkeys.jentitytest.framework.JEntityTestException;
 
 import java.beans.PropertyDescriptor;
@@ -11,6 +13,8 @@ import java.time.temporal.Temporal;
 
 public class DateTimeComparator extends SingleResultComparator {
 
+    private final NullComparison nullComparisonHelper = new NullComparison();
+
     private int delta = 0;
     private ChronoUnit unit = ChronoUnit.NANOS;
 
@@ -18,9 +22,9 @@ public class DateTimeComparator extends SingleResultComparator {
     protected ComparisonResult computeSingleComparison(PropertyDescriptor property, Object a, Object e, ComparisonContext context) {
         ComparisonResult result = new ComparisonResult(false, context, a, e);
 
-        if (a == null && e == null) {
-            result.setPassed(true);
-            return result;
+        NullComparisonResult nullComparisonResult = nullComparisonHelper.compareOnNulls(a, e, context);
+        if (!nullComparisonResult.isPassed() || nullComparisonResult.isStopComparison()) {
+            return nullComparisonResult;
         }
 
         if (!(a instanceof Temporal) && !(e instanceof Temporal))

--- a/src/main/java/org/testmonkeys/jentitytest/comparison/property/DateTimeComparator.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/property/DateTimeComparator.java
@@ -3,7 +3,7 @@ package org.testmonkeys.jentitytest.comparison.property;
 import org.testmonkeys.jentitytest.comparison.ComparisonContext;
 import org.testmonkeys.jentitytest.comparison.SingleResultComparator;
 import org.testmonkeys.jentitytest.comparison.result.ComparisonResult;
-import org.testmonkeys.jentitytest.comparison.util.NullComparison;
+import org.testmonkeys.jentitytest.comparison.util.NullComparator;
 import org.testmonkeys.jentitytest.comparison.util.NullComparisonResult;
 import org.testmonkeys.jentitytest.framework.JEntityTestException;
 
@@ -13,7 +13,7 @@ import java.time.temporal.Temporal;
 
 public class DateTimeComparator extends SingleResultComparator {
 
-    private final NullComparison nullComparisonHelper = new NullComparison();
+    private final NullComparator nullComparatorHelper = new NullComparator();
 
     private int delta = 0;
     private ChronoUnit unit = ChronoUnit.NANOS;
@@ -22,8 +22,8 @@ public class DateTimeComparator extends SingleResultComparator {
     protected ComparisonResult computeSingleComparison(PropertyDescriptor property, Object a, Object e, ComparisonContext context) {
         ComparisonResult result = new ComparisonResult(false, context, a, e);
 
-        NullComparisonResult nullComparisonResult = nullComparisonHelper.compareOnNulls(a, e, context);
-        if (!nullComparisonResult.isPassed() || nullComparisonResult.isStopComparison()) {
+        NullComparisonResult nullComparisonResult = nullComparatorHelper.compareOnNulls(a, e, context);
+        if (!nullComparisonResult.isPassed() || nullComparisonResult.stopComparison()) {
             return nullComparisonResult;
         }
 

--- a/src/main/java/org/testmonkeys/jentitytest/comparison/util/NullComparator.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/util/NullComparator.java
@@ -2,7 +2,7 @@ package org.testmonkeys.jentitytest.comparison.util;
 
 import org.testmonkeys.jentitytest.comparison.ComparisonContext;
 
-public class NullComparison {
+public class NullComparator {
 
     public NullComparisonResult compareOnNulls(Object actual, Object expected, ComparisonContext context) {
         NullComparisonResult result = new NullComparisonResult(true, context, actual, expected);

--- a/src/main/java/org/testmonkeys/jentitytest/comparison/util/NullComparison.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/util/NullComparison.java
@@ -1,0 +1,23 @@
+package org.testmonkeys.jentitytest.comparison.util;
+
+import org.testmonkeys.jentitytest.comparison.ComparisonContext;
+
+public class NullComparison {
+
+    public NullComparisonResult compareOnNulls(Object actual, Object expected, ComparisonContext context) {
+        NullComparisonResult result = new NullComparisonResult(true, context, actual, expected);
+
+        if (actual == null && expected == null) {
+            result.setStopComparison(true);
+            return result;
+        }
+
+        if (actual != null && expected != null)
+            return result;
+
+        result.setPassed(false);
+        result.setExpected(expected == null ? "null" : "not null");
+        result.setActual(actual == null ? "null" : "not null");
+        return result;
+    }
+}

--- a/src/main/java/org/testmonkeys/jentitytest/comparison/util/NullComparisonResult.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/util/NullComparisonResult.java
@@ -1,0 +1,21 @@
+package org.testmonkeys.jentitytest.comparison.util;
+
+import org.testmonkeys.jentitytest.comparison.ComparisonContext;
+import org.testmonkeys.jentitytest.comparison.result.ComparisonResult;
+
+public class NullComparisonResult extends ComparisonResult {
+
+    private boolean stopComparison;
+
+    public NullComparisonResult(boolean passed, ComparisonContext context, Object actual, Object expected) {
+        super(passed, context, actual, expected);
+    }
+
+    public boolean isStopComparison() {
+        return stopComparison;
+    }
+
+    public void setStopComparison(boolean stopComparison) {
+        this.stopComparison = stopComparison;
+    }
+}

--- a/src/main/java/org/testmonkeys/jentitytest/comparison/util/NullComparisonResult.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/util/NullComparisonResult.java
@@ -11,7 +11,7 @@ public class NullComparisonResult extends ComparisonResult {
         super(passed, context, actual, expected);
     }
 
-    public boolean isStopComparison() {
+    public boolean stopComparison() {
         return stopComparison;
     }
 

--- a/src/test/java/org/testmonkeys/jentitytest/test/unit/strategies/entityComparator/EntityComparatorTests.java
+++ b/src/test/java/org/testmonkeys/jentitytest/test/unit/strategies/entityComparator/EntityComparatorTests.java
@@ -1,0 +1,13 @@
+package org.testmonkeys.jentitytest.test.unit.strategies.entityComparator;
+
+import org.junit.Test;
+import org.testmonkeys.jentitytest.comparison.entity.EntityComparator;
+
+public class EntityComparatorTests {
+
+    @Test
+    public void unit_strategy_entityComparator_expectedNull(){
+        EntityComparator comparator=new EntityComparator();
+        comparator.compare(new SimpleModel("test",123),null);
+    }
+}

--- a/src/test/java/org/testmonkeys/jentitytest/test/unit/strategies/entityComparator/SimpleModel.java
+++ b/src/test/java/org/testmonkeys/jentitytest/test/unit/strategies/entityComparator/SimpleModel.java
@@ -1,0 +1,28 @@
+package org.testmonkeys.jentitytest.test.unit.strategies.entityComparator;
+
+public class SimpleModel {
+
+    private String name;
+    private int age;
+
+    public SimpleModel(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
adding NullComparison helper class for consistency in all expected/actual null checks. Updated current strategies to use the null comparison, added NullComparisonResult that contains an extra property to indicate that comparison should stop(null/null case).