### PR TITLE
Dev issue #65 adding Validators

### DIFF
--- a/src/main/java/org/testmonkeys/jentitytest/EntityComparator.java
+++ b/src/main/java/org/testmonkeys/jentitytest/EntityComparator.java
@@ -60,18 +60,6 @@ public class EntityComparator {
         for (PropertyDescriptor propertyDescriptor : model.getComparableProperties()) {
             ComparisonContext propContext = context.withProperty(propertyDescriptor.getName());
             ResultSet results=runChecksForField(model,propertyDescriptor, actual,expected, propContext);
-//            //Abort Conditions block
-//            if (model.hasAbortConditions(propertyDescriptor))
-//                for (AbstractAbortCondition preConditionalChecks:model.getAbortConditionChecks(propertyDescriptor)){
-//                    conditionalCheckResult = preConditionalChecks.check(propertyDescriptor,actual, expected, propContext);
-//                    if ((conditionalCheckResult.getStatus() == Failed) || conditionalCheckResult.isComparisonFinished()) {
-//                        return new ResultSet().with(conditionalCheckResult);
-//                    }
-//                }
-//
-//            //comparison block
-//            PropertyComparisonWrapper comparator = model.getComparator(propertyDescriptor);
-//            comparisonResults.addAll(comparator.compare(propertyDescriptor, actual, expected, propContext));
             comparisonResults.addAll(results);
         }
         return comparisonResults;

--- a/src/main/java/org/testmonkeys/jentitytest/comparison/AbstractCheck.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/AbstractCheck.java
@@ -1,0 +1,46 @@
+package org.testmonkeys.jentitytest.comparison;
+
+import org.testmonkeys.jentitytest.Resources;
+import org.testmonkeys.jentitytest.comparison.result.ConditionalCheckResult;
+import org.testmonkeys.jentitytest.comparison.result.Status;
+import org.testmonkeys.jentitytest.exceptions.JEntityTestException;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Base class for Abort Condition Checks, acts as a wrapper and makes all abort conditions implement the strategy
+ * pattern
+ */
+public abstract class AbstractCheck {
+
+    /**
+     * @param property property on which the check will run
+     * @param actual actual parent object of the property
+     * @param expected expected parent object of the property
+     * @param context comparison context
+     * @return conditional check result
+     * @throws JEntityTestException
+     */
+    public ConditionalCheckResult check(PropertyDescriptor property, Object actual, Object expected, ComparisonContext context) {
+        Object actualValue = getPropertyValue(property, actual);
+        Object expectedValue = getPropertyValue(property, expected);
+
+        if (context.isRecursive(actualValue))
+            return new ConditionalCheckResult(Status.Passed,context,actualValue,expectedValue);
+        context.setActualObj(actualValue);
+        return runCheck(actualValue, expectedValue, context);
+    }
+
+    protected abstract ConditionalCheckResult runCheck(Object actualValue, Object expectedValue, ComparisonContext context);
+
+    @SuppressWarnings("WeakerAccess")
+    protected Object getPropertyValue(PropertyDescriptor property, Object obj) {
+        try {
+            return property.getReadMethod().invoke(obj);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new JEntityTestException(Resources.getString(Resources.err_could_not_read_property), e);
+        }
+    }
+
+}

--- a/src/main/java/org/testmonkeys/jentitytest/comparison/validations/AbstractValidation.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/validations/AbstractValidation.java
@@ -1,24 +1,20 @@
-package org.testmonkeys.jentitytest.comparison.abortConditions;
+package org.testmonkeys.jentitytest.comparison.validations;
 
 import org.testmonkeys.jentitytest.Resources;
 import org.testmonkeys.jentitytest.comparison.AbstractCheck;
-import org.testmonkeys.jentitytest.comparison.Comparator;
 import org.testmonkeys.jentitytest.comparison.ComparisonContext;
-import org.testmonkeys.jentitytest.comparison.result.ComparisonResult;
 import org.testmonkeys.jentitytest.comparison.result.ConditionalCheckResult;
-import org.testmonkeys.jentitytest.comparison.result.ResultSet;
 import org.testmonkeys.jentitytest.comparison.result.Status;
 import org.testmonkeys.jentitytest.exceptions.JEntityTestException;
 
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Collection;
 
 /**
  * Base class for Abort Condition Checks, acts as a wrapper and makes all abort conditions implement the strategy
  * pattern
  */
-public abstract class AbstractAbortCondition extends AbstractCheck {
+public abstract class AbstractValidation extends AbstractCheck {
 
 
 

--- a/src/main/java/org/testmonkeys/jentitytest/comparison/validations/NotNullValidator.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/validations/NotNullValidator.java
@@ -1,0 +1,22 @@
+package org.testmonkeys.jentitytest.comparison.validations;
+
+import org.testmonkeys.jentitytest.comparison.ComparisonContext;
+import org.testmonkeys.jentitytest.comparison.abortConditions.AbstractAbortCondition;
+import org.testmonkeys.jentitytest.comparison.result.ConditionalCheckResult;
+
+import static org.testmonkeys.jentitytest.comparison.result.Status.Failed;
+import static org.testmonkeys.jentitytest.comparison.result.Status.Passed;
+
+public class NotNullValidator extends AbstractValidation {
+
+    public ConditionalCheckResult runCheck(Object actual, Object expected, ComparisonContext context) {
+        context.setComparatorDetails("NotNullValidator");
+        ConditionalCheckResult result = new ConditionalCheckResult(Passed, context, actual, expected);
+
+        if (actual == null) {
+            result.setStatus(Failed);
+
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/testmonkeys/jentitytest/comparison/validations/RegexValidation.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/validations/RegexValidation.java
@@ -1,0 +1,44 @@
+package org.testmonkeys.jentitytest.comparison.validations;
+
+import com.sun.net.httpserver.Authenticator;
+import org.testmonkeys.jentitytest.Resources;
+import org.testmonkeys.jentitytest.comparison.AbstractComparator;
+import org.testmonkeys.jentitytest.comparison.ComparisonContext;
+import org.testmonkeys.jentitytest.comparison.conditionalChecks.NullConditionalCheck;
+import org.testmonkeys.jentitytest.comparison.result.ConditionalCheckResult;
+import org.testmonkeys.jentitytest.comparison.result.ResultSet;
+import org.testmonkeys.jentitytest.comparison.result.Status;
+import org.testmonkeys.jentitytest.exceptions.JEntityTestException;
+import org.testmonkeys.jentitytest.framework.StringComparison;
+import org.testmonkeys.jentitytest.framework.ValidateRegex;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.testmonkeys.jentitytest.comparison.result.Status.Failed;
+import static org.testmonkeys.jentitytest.comparison.result.Status.Passed;
+
+public class RegexValidation extends AbstractValidation {
+
+    private final String regExp;
+    private final ValidateRegex.NullHandling nullHandling;
+
+    public RegexValidation(ValidateRegex annotation) {
+        regExp = annotation.expression();
+        nullHandling = annotation.nullHandling();
+    }
+
+    public ConditionalCheckResult runCheck(Object actual, Object expected, ComparisonContext context) {
+        context.setComparatorDetails("RegexValidation with regular expression: "+ regExp);
+        ConditionalCheckResult result = new ConditionalCheckResult(Passed, context, actual, expected);
+
+        if (nullHandling != ValidateRegex.NullHandling.Pass || actual != null) {
+            if (!Pattern.matches(regExp, String.valueOf(actual))) {
+                result.setStatus(Failed);
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/testmonkeys/jentitytest/exceptions/CheckInstantiationException.java
+++ b/src/main/java/org/testmonkeys/jentitytest/exceptions/CheckInstantiationException.java
@@ -1,16 +1,17 @@
 package org.testmonkeys.jentitytest.exceptions;
 
 import org.testmonkeys.jentitytest.Resources;
+import org.testmonkeys.jentitytest.comparison.AbstractCheck;
 import org.testmonkeys.jentitytest.comparison.abortConditions.AbstractAbortCondition;
 
 import java.lang.annotation.Annotation;
 import java.text.MessageFormat;
 
 
-public class PreComparisonCheckInstantiationException extends RuntimeException {
+public class CheckInstantiationException extends RuntimeException {
 
-    public PreComparisonCheckInstantiationException(Class<? extends AbstractAbortCondition> comparator, Annotation annotation,
-                                                    Exception e) {
+    public CheckInstantiationException(Class<? extends AbstractCheck> comparator, Annotation annotation,
+                                       Exception e) {
         super(MessageFormat.format(Resources.getString(Resources.err_creating_comparator_for_annotation),comparator,
                 annotation.getClass().getName(), e));
     }

--- a/src/main/java/org/testmonkeys/jentitytest/framework/ValidateNotNull.java
+++ b/src/main/java/org/testmonkeys/jentitytest/framework/ValidateNotNull.java
@@ -1,0 +1,11 @@
+package org.testmonkeys.jentitytest.framework;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface ValidateNotNull {
+}

--- a/src/main/java/org/testmonkeys/jentitytest/framework/ValidateRegex.java
+++ b/src/main/java/org/testmonkeys/jentitytest/framework/ValidateRegex.java
@@ -1,0 +1,24 @@
+package org.testmonkeys.jentitytest.framework;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface ValidateRegex {
+    String expression() default "";
+    RegexMatching matching() default RegexMatching.Strict;
+    NullHandling nullHandling() default NullHandling.Fail;
+
+    enum RegexMatching{
+        Strict
+    }
+
+    enum NullHandling{
+        Fail,
+        Pass
+    }
+
+}

--- a/src/main/java/org/testmonkeys/jentitytest/model/AnnotationToComparatorDictionary.java
+++ b/src/main/java/org/testmonkeys/jentitytest/model/AnnotationToComparatorDictionary.java
@@ -10,6 +10,7 @@ import org.testmonkeys.jentitytest.comparison.abortConditions.AbortOnExpectNullC
 import org.testmonkeys.jentitytest.comparison.strategies.*;
 import org.testmonkeys.jentitytest.comparison.validations.AbstractValidation;
 import org.testmonkeys.jentitytest.comparison.validations.NotNullValidator;
+import org.testmonkeys.jentitytest.comparison.validations.RegexValidation;
 import org.testmonkeys.jentitytest.exceptions.*;
 import org.testmonkeys.jentitytest.framework.*;
 
@@ -47,6 +48,7 @@ public final class AnnotationToComparatorDictionary {
         setComparatorForAnnotation(StringComparator.class,StringComparison.class);
         setComparatorForAnnotation(ChildEntityListComparator.class,ChildEntityListComparison.class);
         setValidatorForAnnotation(NotNullValidator.class,ValidateNotNull.class);
+        setValidatorForAnnotation(RegexValidation.class,ValidateRegex.class);
     }
 
     public static synchronized AnnotationToComparatorDictionary getInstance() {

--- a/src/main/java/org/testmonkeys/jentitytest/model/AnnotationToComparatorDictionary.java
+++ b/src/main/java/org/testmonkeys/jentitytest/model/AnnotationToComparatorDictionary.java
@@ -3,10 +3,13 @@ package org.testmonkeys.jentitytest.model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testmonkeys.jentitytest.Resources;
+import org.testmonkeys.jentitytest.comparison.AbstractCheck;
 import org.testmonkeys.jentitytest.comparison.Comparator;
 import org.testmonkeys.jentitytest.comparison.abortConditions.AbstractAbortCondition;
 import org.testmonkeys.jentitytest.comparison.abortConditions.AbortOnExpectNullCondition;
 import org.testmonkeys.jentitytest.comparison.strategies.*;
+import org.testmonkeys.jentitytest.comparison.validations.AbstractValidation;
+import org.testmonkeys.jentitytest.comparison.validations.NotNullValidator;
 import org.testmonkeys.jentitytest.exceptions.*;
 import org.testmonkeys.jentitytest.framework.*;
 
@@ -30,17 +33,20 @@ public final class AnnotationToComparatorDictionary {
     private static AnnotationToComparatorDictionary instance;
     private final Map<Class<?>, Class<? extends Comparator>> mapping;
     private final Map<Class<?>, Class<? extends AbstractAbortCondition>> preConditionalMapping;
+    private final Map<Class<?>, Class<? extends AbstractValidation>> validationsMapping;
 
     private AnnotationToComparatorDictionary() {
         LOG.debug("Initializing Annotation to Comparator Dictionary"); //LOG
         mapping = new HashMap<>();
         preConditionalMapping=new HashMap<>();
+        validationsMapping = new HashMap<>();
         setPreConditionalCheckForAnnotation(AbortOnExpectNullCondition.class, IgnoreComparisonIfExpectedNull.class);
         setComparatorForAnnotation(IgnoreComparator.class,IgnoreComparison.class);
         setComparatorForAnnotation(ChildEntityComparator.class,ChildEntityComparison.class);
         setComparatorForAnnotation(DateTimeComparator.class,DateTimeComparison.class);
         setComparatorForAnnotation(StringComparator.class,StringComparison.class);
         setComparatorForAnnotation(ChildEntityListComparator.class,ChildEntityListComparison.class);
+        setValidatorForAnnotation(NotNullValidator.class,ValidateNotNull.class);
     }
 
     public static synchronized AnnotationToComparatorDictionary getInstance() {
@@ -69,6 +75,17 @@ public final class AnnotationToComparatorDictionary {
     public boolean hasPreConditionalCheckAssigned(Annotation candidate) {
         LOG.trace("Checking if {} has a comparator assigned",candidate); //LOG
         return preConditionalMapping.containsKey(candidate.annotationType());
+    }
+
+    /**
+     * Checks if provided annotation is linked to a validator
+     *
+     * @param candidate annotation to check
+     * @return boolean result of verification
+     */
+    public boolean hasValidationCheckAssigned(Annotation candidate) {
+        LOG.trace("Checking if {} has a comparator assigned",candidate); //LOG
+        return validationsMapping.containsKey(candidate.annotationType());
     }
 
     /**
@@ -101,6 +118,22 @@ public final class AnnotationToComparatorDictionary {
         if (annotation == null)
             throw new IllegalArgumentException(Resources.getString(Resources.err_annotation_null));
         preConditionalMapping.put(annotation, comparator);
+    }
+
+    /**
+     * Register or overwrite a mapping between an annotation and a comparator
+     *
+     * @param comparator comparator to register
+     * @param annotation annotation to register
+     * @throws JEntityTestException in case the comparator or annotation is null
+     */
+    public void setValidatorForAnnotation(Class<? extends AbstractValidation> comparator, Class<?> annotation) {
+        LOG.debug("Registering Comparator {} for Annotation {}",comparator,annotation); //LOG
+        if (comparator == null)
+            throw new IllegalArgumentException(Resources.getString(Resources.err_comparator_null));
+        if (annotation == null)
+            throw new IllegalArgumentException(Resources.getString(Resources.err_annotation_null));
+        validationsMapping.put(annotation, comparator);
     }
 
     /**
@@ -137,7 +170,28 @@ public final class AnnotationToComparatorDictionary {
             throw new IllegalArgumentException(Resources.getString(Resources.err_annotation_null));
 
         if (preConditionalMapping.containsKey(annotation.annotationType())) {
-            return initializePreComparisonCheck(annotation, preConditionalMapping.get(annotation.annotationType()));
+            return initializeCheck(annotation, preConditionalMapping.get(annotation.annotationType()));
+        }
+
+        throw new JEntityModelException(
+                MessageFormat.format(Resources.getString(Resources.ERR_NO_COMPARATOR_DEFINED_FOR_ANNOTATION),
+                        annotation.annotationType().getName()));
+    }
+
+    /**
+     * Gets the comparator assigned to the provided annotation
+     *
+     * @param annotation annotation
+     * @return Comparator for provided annotation
+     * @throws JEntityTestException in case comparator could not be provided
+     */
+    public AbstractValidation getValidationForAnnotation(Annotation annotation) {
+        LOG.trace("Getting validation check for Annotation {}",annotation); //LOG
+        if (annotation == null)
+            throw new IllegalArgumentException(Resources.getString(Resources.err_annotation_null));
+
+        if (validationsMapping.containsKey(annotation.annotationType())) {
+            return initializeCheck(annotation, validationsMapping.get(annotation.annotationType()));
         }
 
         throw new JEntityModelException(
@@ -186,7 +240,7 @@ public final class AnnotationToComparatorDictionary {
      * @return
      * @throws JEntityTestException
      */
-    private AbstractAbortCondition initializePreComparisonCheck(Annotation annotation, Class<? extends AbstractAbortCondition> type) {
+    private  <T> T initializeCheck(Annotation annotation, Class<? extends AbstractCheck> type) {
         LOG.trace("Starting initialization for comparator {}",type); //LOG
         Constructor[] constructors = type.getDeclaredConstructors();
         Constructor annotationConstructor = null;
@@ -201,17 +255,17 @@ public final class AnnotationToComparatorDictionary {
         try {
             if (annotationConstructor != null) {
                 LOG.trace("Initializing comparator {} using constructor with annotation parameter", type); //LOG
-                return (AbstractAbortCondition) annotationConstructor.newInstance(annotation);
+                return (T) annotationConstructor.newInstance(annotation);
             } else {
                 LOG.trace("Initializing comparator {} using default constructor", type); //LOG
-                return type.getConstructor().newInstance();
+                return (T) type.getConstructor().newInstance();
             }
         } catch (InstantiationException e) {
-            throw new PreComparisonCheckInstantiationException(type, annotation, e);
+            throw new CheckInstantiationException(type, annotation, e);
         } catch (IllegalAccessException e) {
-            throw new PreComparisonCheckInstantiationException(type, annotation, e);
+            throw new CheckInstantiationException(type, annotation, e);
         } catch (Exception e) {
-            throw new PreComparisonCheckInstantiationException(type, annotation, e);
+            throw new CheckInstantiationException(type, annotation, e);
         }
     }
 

--- a/src/main/java/org/testmonkeys/jentitytest/model/ComparisonModel.java
+++ b/src/main/java/org/testmonkeys/jentitytest/model/ComparisonModel.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import org.testmonkeys.jentitytest.comparison.PropertyComparisonWrapper;
 import org.testmonkeys.jentitytest.comparison.abortConditions.AbstractAbortCondition;
+import org.testmonkeys.jentitytest.comparison.validations.AbstractValidation;
 
 import java.beans.PropertyDescriptor;
 import java.util.*;
@@ -16,14 +17,46 @@ import java.util.*;
 public class ComparisonModel {
 
     private static final Logger LOG = LoggerFactory.getLogger(ComparisonModel.class);
+    private final Map<PropertyDescriptor, List<AbstractValidation>> validations;
     private final Map<PropertyDescriptor, List<AbstractAbortCondition>> abortConditions;
     private final Map<PropertyDescriptor, PropertyComparisonWrapper> comparisonMap;
 
 
     public ComparisonModel() {
         LOG.debug("Creating new comparison model"); //LOG
+        validations = new HashMap<>();
         abortConditions = new HashMap<>();
         comparisonMap = new HashMap<>();
+    }
+
+    /**
+     * Adds a validation point for the property
+     * @param propertyDescriptor property to add to the comparison
+     * @param validation validation used for this property
+     */
+    public void setValidation(PropertyDescriptor propertyDescriptor, AbstractValidation validation) {
+        LOG.debug("Adding validation for {} using {}", propertyDescriptor.getName(), validation); //LOG
+        if (!validations.containsKey(propertyDescriptor))
+            validations.put(propertyDescriptor,new ArrayList<>());
+        validations.get(propertyDescriptor).add(validation);
+    }
+
+    /**
+     * Gets the validation checks for the provided propertyDescriptor in the current model
+     * @param propertyDescriptor
+     * @return list of validation checks
+     */
+    public List<AbstractValidation> getValidations(PropertyDescriptor propertyDescriptor) {
+        return validations.get(propertyDescriptor);
+    }
+
+    /**
+     * Checks if there are any validation checks registered for provided propertyDescriptor in the current model
+     * @param propertyDescriptor
+     * @return
+     */
+    public boolean hasValidations(PropertyDescriptor propertyDescriptor) {
+        return validations.containsKey(propertyDescriptor);
     }
 
     /**

--- a/src/main/java/org/testmonkeys/jentitytest/model/EntityInspector.java
+++ b/src/main/java/org/testmonkeys/jentitytest/model/EntityInspector.java
@@ -53,6 +53,9 @@ public class EntityInspector {
                 for (Annotation annotation:getPreConditionalChecksAnnotation(field)){
                     model.setAbortCondition(propertyDescriptor,annotationToComparator.getPreComparisonCheckForAnnotation(annotation));
                 }
+                for (Annotation annotation:getValidationChecksAnnotation(field)){
+                    model.setValidation(propertyDescriptor,annotationToComparator.getValidationForAnnotation(annotation));
+                }
                 Annotation annotation = getComparisonAnnotation(field);
                 if (annotation != null) {
                     LOG.debug("Found annotation at field level"); //LOG
@@ -64,6 +67,9 @@ public class EntityInspector {
             //Method level processing
             for (Annotation annotation:getPreConditionalChecksAnnotation(method)){
                 model.setAbortCondition(propertyDescriptor,annotationToComparator.getPreComparisonCheckForAnnotation(annotation));
+            }
+            for (Annotation annotation:getValidationChecksAnnotation(method)){
+                model.setValidation(propertyDescriptor,annotationToComparator.getValidationForAnnotation(annotation));
             }
             Annotation annotation = getComparisonAnnotation(method);
             if (annotation != null) {
@@ -109,6 +115,16 @@ public class EntityInspector {
         List<Annotation> knownAnnotations = new ArrayList<>();
         for (Annotation candidate : member.getAnnotations()) {
             if (annotationToComparator.hasPreConditionalCheckAssigned(candidate)) {
+                knownAnnotations.add(candidate);
+            }
+        }
+        return knownAnnotations;
+    }
+
+    private List<Annotation> getValidationChecksAnnotation(AnnotatedElement member) {
+        List<Annotation> knownAnnotations = new ArrayList<>();
+        for (Annotation candidate : member.getAnnotations()) {
+            if (annotationToComparator.hasValidationCheckAssigned(candidate)) {
                 knownAnnotations.add(candidate);
             }
         }

--- a/src/test/java/org/testmonkeys/jentitytest/test/integration/validations/validateNotNull/ignoreAnnotation/SimpleModelWithIgnore.java
+++ b/src/test/java/org/testmonkeys/jentitytest/test/integration/validations/validateNotNull/ignoreAnnotation/SimpleModelWithIgnore.java
@@ -1,0 +1,37 @@
+package org.testmonkeys.jentitytest.test.integration.validations.validateNotNull.ignoreAnnotation;
+
+import org.testmonkeys.jentitytest.framework.IgnoreComparison;
+import org.testmonkeys.jentitytest.framework.IgnoreComparisonIfExpectedNull;
+import org.testmonkeys.jentitytest.framework.ValidateNotNull;
+
+public class SimpleModelWithIgnore {
+
+
+
+    private String name;
+    private int age;
+
+    public SimpleModelWithIgnore(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    @IgnoreComparison
+    public int getAge() {
+        return this.age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    @ValidateNotNull
+    @IgnoreComparisonIfExpectedNull
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/org/testmonkeys/jentitytest/test/integration/validations/validateNotNull/ignoreAnnotation/ValidateNotNullTest.java
+++ b/src/test/java/org/testmonkeys/jentitytest/test/integration/validations/validateNotNull/ignoreAnnotation/ValidateNotNullTest.java
@@ -1,0 +1,32 @@
+package org.testmonkeys.jentitytest.test.integration.validations.validateNotNull.ignoreAnnotation;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.testmonkeys.jentitytest.hamcrest.Entity;
+
+public class ValidateNotNullTest {
+
+    @Test
+    public void testPassing() {
+
+        SimpleModelWithIgnore expected = new SimpleModelWithIgnore("John", 26);
+        SimpleModelWithIgnore actual = new SimpleModelWithIgnore("John", 27);
+        Assert.assertThat(actual, Entity.isEqualTo(expected));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testFailing() {
+
+        SimpleModelWithIgnore expected = new SimpleModelWithIgnore("Johan", 26);
+        SimpleModelWithIgnore actual = new SimpleModelWithIgnore("John", 26);
+        Assert.assertThat(actual, Entity.isEqualTo(expected));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testFailing2() {
+
+        SimpleModelWithIgnore expected = new SimpleModelWithIgnore("Johan", 26);
+        SimpleModelWithIgnore actual = new SimpleModelWithIgnore(null, 26);
+        Assert.assertThat(actual, Entity.isEqualTo(expected));
+    }
+}

--- a/src/test/java/org/testmonkeys/jentitytest/test/integration/validations/validateRegexp/SimpleModelWithRegexp.java
+++ b/src/test/java/org/testmonkeys/jentitytest/test/integration/validations/validateRegexp/SimpleModelWithRegexp.java
@@ -1,0 +1,37 @@
+package org.testmonkeys.jentitytest.test.integration.validations.validateRegexp;
+
+import org.testmonkeys.jentitytest.framework.IgnoreComparison;
+import org.testmonkeys.jentitytest.framework.IgnoreComparisonIfExpectedNull;
+import org.testmonkeys.jentitytest.framework.ValidateNotNull;
+import org.testmonkeys.jentitytest.framework.ValidateRegex;
+
+public class SimpleModelWithRegexp {
+
+
+
+    private String name;
+    private int age;
+
+    public SimpleModelWithRegexp(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    @IgnoreComparison
+    public int getAge() {
+        return this.age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    @ValidateRegex(expression = "J..n")
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/org/testmonkeys/jentitytest/test/integration/validations/validateRegexp/SimpleModelWithRegexpPassOnNull.java
+++ b/src/test/java/org/testmonkeys/jentitytest/test/integration/validations/validateRegexp/SimpleModelWithRegexpPassOnNull.java
@@ -1,0 +1,37 @@
+package org.testmonkeys.jentitytest.test.integration.validations.validateRegexp;
+
+import org.testmonkeys.jentitytest.framework.IgnoreComparison;
+import org.testmonkeys.jentitytest.framework.IgnoreComparisonIfExpectedNull;
+import org.testmonkeys.jentitytest.framework.ValidateRegex;
+
+public class SimpleModelWithRegexpPassOnNull {
+
+
+
+    private String name;
+    private int age;
+
+    public SimpleModelWithRegexpPassOnNull(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    @IgnoreComparison
+    public int getAge() {
+        return this.age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    @ValidateRegex(expression = "J..n", nullHandling = ValidateRegex.NullHandling.Pass)
+    @IgnoreComparisonIfExpectedNull
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/org/testmonkeys/jentitytest/test/integration/validations/validateRegexp/ValidateRegexpTest.java
+++ b/src/test/java/org/testmonkeys/jentitytest/test/integration/validations/validateRegexp/ValidateRegexpTest.java
@@ -1,0 +1,46 @@
+package org.testmonkeys.jentitytest.test.integration.validations.validateRegexp;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.testmonkeys.jentitytest.hamcrest.Entity;
+
+public class ValidateRegexpTest {
+
+    @Test
+    public void testPassing() {
+
+        SimpleModelWithRegexp expected = new SimpleModelWithRegexp("John", 26);
+        SimpleModelWithRegexp actual = new SimpleModelWithRegexp("John", 27);
+        Assert.assertThat(actual, Entity.isEqualTo(expected));
+    }
+    @Test
+    public void testPassing1() {
+
+        SimpleModelWithRegexpPassOnNull expected = new SimpleModelWithRegexpPassOnNull(null, 26);
+        SimpleModelWithRegexpPassOnNull actual = new SimpleModelWithRegexpPassOnNull(null, 27);
+        Assert.assertThat(actual, Entity.isEqualTo(expected));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testFailing0() {
+
+        SimpleModelWithRegexp expected = new SimpleModelWithRegexp("Jonh", 26);
+        SimpleModelWithRegexp actual = new SimpleModelWithRegexp("Jonh", 27);
+        Assert.assertThat(actual, Entity.isEqualTo(expected));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testFailing() {
+
+        SimpleModelWithRegexp expected = new SimpleModelWithRegexp(null, 26);
+        SimpleModelWithRegexp actual = new SimpleModelWithRegexp(null, 26);
+        Assert.assertThat(actual, Entity.isEqualTo(expected));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testFailing2() {
+        SimpleModelWithRegexp expected = new SimpleModelWithRegexp("Johan", 26);
+        SimpleModelWithRegexp actual = new SimpleModelWithRegexp(null, 26);
+        Assert.assertThat(actual, Entity.isEqualTo(expected));
+    }
+}


### PR DESCRIPTION
Adding Validators, with initial implementation for NotNull and Regex Validations.
Current implementation treats validators as comparators, which is a bit confusing as they are accepting expected objects but are not using them in any way, and the error display message will provide details as in comparison results.. despite them being Validators... Further refinement si needed to make the output more clean.