### PR TITLE
Adding regex comparison support for fields

### DIFF
--- a/src/main/java/org/testmonkeys/jentitytest/comparison/strategies/RegexComparator.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/strategies/RegexComparator.java
@@ -1,0 +1,49 @@
+package org.testmonkeys.jentitytest.comparison.strategies;
+
+import org.testmonkeys.jentitytest.Resources;
+import org.testmonkeys.jentitytest.comparison.AbstractComparator;
+import org.testmonkeys.jentitytest.comparison.ComparisonContext;
+import org.testmonkeys.jentitytest.comparison.conditionalChecks.NullConditionalCheck;
+import org.testmonkeys.jentitytest.comparison.result.ResultSet;
+import org.testmonkeys.jentitytest.comparison.result.Status;
+import org.testmonkeys.jentitytest.exceptions.JEntityTestException;
+import org.testmonkeys.jentitytest.framework.StringComparison;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class RegexComparator extends AbstractComparator {
+
+    public RegexComparator() {
+        registerPreConditionalCheck(new NullConditionalCheck());
+    }
+
+
+    public ResultSet computeComparison(Object actual, Object expected, ComparisonContext context) {
+        String actualValue;
+        String expectedValue;
+
+        try {
+            actualValue = (String) actual;
+            expectedValue = (String) expected;
+        } catch (ClassCastException castException) {
+            throw new JEntityTestException(MessageFormat.format(
+                    Resources.getString(Resources.err_actual_and_expected_must_be_of_type), String.class.getName()),
+                    castException);
+        }
+
+        Status status;
+            status = Status.valueOf(Pattern.matches(expectedValue,actualValue));
+
+        return new ResultSet().with(status, context, actualValue, expectedValue);
+    }
+
+    @Override
+    protected String describe() {
+        return getClass().getSimpleName();
+    }
+
+
+}

--- a/src/main/java/org/testmonkeys/jentitytest/comparison/strategies/RegexComparator.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/strategies/RegexComparator.java
@@ -34,8 +34,7 @@ public class RegexComparator extends AbstractComparator {
                     castException);
         }
 
-        Status status;
-            status = Status.valueOf(Pattern.matches(expectedValue,actualValue));
+        Status status = Status.valueOf(Pattern.matches(expectedValue,actualValue));
 
         return new ResultSet().with(status, context, actualValue, expectedValue);
     }

--- a/src/main/java/org/testmonkeys/jentitytest/framework/RegexInExpected.java
+++ b/src/main/java/org/testmonkeys/jentitytest/framework/RegexInExpected.java
@@ -1,0 +1,12 @@
+package org.testmonkeys.jentitytest.framework;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface RegexInExpected {
+
+}

--- a/src/main/java/org/testmonkeys/jentitytest/model/AnnotationToComparatorDictionary.java
+++ b/src/main/java/org/testmonkeys/jentitytest/model/AnnotationToComparatorDictionary.java
@@ -47,6 +47,7 @@ public final class AnnotationToComparatorDictionary {
         setComparatorForAnnotation(DateTimeComparator.class,DateTimeComparison.class);
         setComparatorForAnnotation(StringComparator.class,StringComparison.class);
         setComparatorForAnnotation(ChildEntityListComparator.class,ChildEntityListComparison.class);
+        setComparatorForAnnotation(RegexComparator.class, RegexInExpected.class);
         setValidatorForAnnotation(NotNullValidator.class,ValidateNotNull.class);
         setValidatorForAnnotation(RegexValidation.class,ValidateRegex.class);
     }

--- a/src/test/java/org/testmonkeys/jentitytest/test/integration/regexComparison/stringComparison/Model.java
+++ b/src/test/java/org/testmonkeys/jentitytest/test/integration/regexComparison/stringComparison/Model.java
@@ -1,0 +1,18 @@
+package org.testmonkeys.jentitytest.test.integration.regexComparison.stringComparison;
+
+import org.testmonkeys.jentitytest.framework.RegexInExpected;
+import org.testmonkeys.jentitytest.framework.StringComparison;
+
+public class Model {
+
+    @RegexInExpected
+    private String field;
+
+    public String getField() {
+        return this.field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+}

--- a/src/test/java/org/testmonkeys/jentitytest/test/integration/regexComparison/stringComparison/RegexComparisonTest.java
+++ b/src/test/java/org/testmonkeys/jentitytest/test/integration/regexComparison/stringComparison/RegexComparisonTest.java
@@ -1,0 +1,32 @@
+package org.testmonkeys.jentitytest.test.integration.regexComparison.stringComparison;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.testmonkeys.jentitytest.hamcrest.Entity;
+
+public class RegexComparisonTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testPassingCase() {
+        Model actual = new Model();
+        actual.setField("Test");
+        Model expected = new Model();
+        expected.setField("T.st");
+        Assert.assertThat(actual, Entity.isEqualTo(expected));
+    }
+
+    @Test (expected = AssertionError.class)
+    public void testFailingCase() {
+        Model actual = new Model();
+        actual.setField("Fest");
+        Model expected = new Model();
+        expected.setField("Rest|Nest");
+        Assert.assertThat(actual, Entity.isEqualTo(expected));
+    }
+
+}


### PR DESCRIPTION
Adding support for regex validations: Expected field can contain a regular expression that the actual must match.