### PR TITLE
Ordered option for ChildEntityListComparator

### DIFF
--- a/src/main/java/org/testmonkeys/jentitytest/comparison/strategies/ChildEntityListComparator.java
+++ b/src/main/java/org/testmonkeys/jentitytest/comparison/strategies/ChildEntityListComparator.java
@@ -7,12 +7,11 @@ import org.testmonkeys.jentitytest.comparison.ComparisonContext;
 import org.testmonkeys.jentitytest.comparison.conditionalChecks.NullConditionalCheck;
 import org.testmonkeys.jentitytest.comparison.result.ComparisonResult;
 import org.testmonkeys.jentitytest.comparison.result.ResultSet;
+import org.testmonkeys.jentitytest.comparison.result.Status;
 import org.testmonkeys.jentitytest.exceptions.JEntityTestException;
+import org.testmonkeys.jentitytest.framework.ChildEntityListComparison;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
+import java.util.*;
 
 import static org.testmonkeys.jentitytest.Resources.err_actual_and_expected_must_be_generic_Collections;
 import static org.testmonkeys.jentitytest.Resources.size;
@@ -20,8 +19,15 @@ import static org.testmonkeys.jentitytest.comparison.result.Status.Failed;
 
 public class ChildEntityListComparator extends AbstractComparator {
 
+    private boolean ordered = true;
+
     public ChildEntityListComparator() {
         registerPreConditionalCheck(new NullConditionalCheck());
+    }
+
+    public ChildEntityListComparator(ChildEntityListComparison annotation) {
+        registerPreConditionalCheck(new NullConditionalCheck());
+        ordered = annotation.ordered();
     }
 
     private static boolean isWrapperType(Object obj) {
@@ -69,6 +75,14 @@ public class ChildEntityListComparator extends AbstractComparator {
         else
             elementComparator = new ChildEntityComparator();
 
+        if (ordered)
+            return computeOrderedComparison(listActual, listExpected, context, elementComparator);
+        else
+            return computeUnOrderedComparison(listActual, listExpected, context, elementComparator);
+    }
+
+    private ResultSet computeOrderedComparison(Collection<?> listActual, Collection<?> listExpected, ComparisonContext context, Comparator elementComparator) {
+        ResultSet comparisonResults = new ResultSet();
         Iterator<?> actualIterator = listActual.iterator();
         Iterator<?> expectedIterator = listExpected.iterator();
         for (int i = 0; i < listActual.size(); i++) {
@@ -81,11 +95,39 @@ public class ChildEntityListComparator extends AbstractComparator {
         return comparisonResults;
     }
 
+    private ResultSet computeUnOrderedComparison(Collection<?> listActual, Collection<?> listExpected, ComparisonContext context, Comparator elementComparator) {
+        ResultSet comparisonResults = new ResultSet();
+
+        Object[] actualArr = listActual.toArray();
+        Object[] expectedArr = listExpected.toArray();
+
+        for (int i = 0; i < listExpected.size(); i++) {
+            List<ResultSet> options = new ArrayList<>();
+            for (int j = 0; j < actualArr.length; j++) {
+                ResultSet option = elementComparator.compare(
+                        actualArr[j],
+                        expectedArr[i],
+                        context.withIndex(i));
+                options.add(option);
+                if (option.stream().allMatch(x -> x.getStatus().equals(Status.Passed) || x.getStatus().equals(Status.Skipped)))
+                    break;
+            }
+            ResultSet closestOption = options.get(0);
+            for (ResultSet option : options) {
+                if (option.stream().filter(x -> x.getStatus().equals(Failed)).count() < closestOption.stream().filter(x -> x.getStatus().equals(Failed)).count())
+                    closestOption = option;
+            }
+            comparisonResults.addAll(closestOption);
+        }
+
+        return comparisonResults;
+    }
+
     private Collection<?> castToCollection(Object object) {
         try {
             return (Collection<?>) object;
         } catch (ClassCastException ex) {
-            throw new JEntityTestException(Resources.getString(err_actual_and_expected_must_be_generic_Collections),ex);
+            throw new JEntityTestException(Resources.getString(err_actual_and_expected_must_be_generic_Collections), ex);
         }
     }
 }

--- a/src/main/java/org/testmonkeys/jentitytest/framework/ChildEntityListComparison.java
+++ b/src/main/java/org/testmonkeys/jentitytest/framework/ChildEntityListComparison.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
 public @interface ChildEntityListComparison {
+    boolean ordered() default true;
 }

--- a/src/test/java/org/testmonkeys/jentitytest/test/integration/childList/ChildEntityUnOrderedListTest.java
+++ b/src/test/java/org/testmonkeys/jentitytest/test/integration/childList/ChildEntityUnOrderedListTest.java
@@ -1,0 +1,109 @@
+package org.testmonkeys.jentitytest.test.integration.childList;
+
+import org.junit.Test;
+import org.testmonkeys.jentitytest.hamcrest.Entity;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertThat;
+
+
+public class ChildEntityUnOrderedListTest {
+
+    @Test
+    public void childEntityComparison() {
+        CompositeUnOrderedModel expected = new CompositeUnOrderedModel();
+        expected.setModelList(new ArrayList<>());
+        SimpleModel expectedItem = new SimpleModel();
+        expectedItem.setAge(1);
+        expected.getModelList().add(expectedItem);
+
+        CompositeUnOrderedModel actual = new CompositeUnOrderedModel();
+        actual.setModelList(new ArrayList<>());
+        SimpleModel actualItem = new SimpleModel();
+        actualItem.setAge(1);
+        actual.getModelList().add(actualItem);
+
+        assertThat(actual, Entity.isEqualTo(expected));
+    }
+
+    @Test
+    public void childEntityListComparisonUnOrdered() {
+        CompositeUnOrderedModel expected = new CompositeUnOrderedModel();
+        expected.setModelList(new ArrayList<>());
+        SimpleModel expectedItem1 = new SimpleModel();
+        expectedItem1.setAge(1);
+        SimpleModel expectedItem2 = new SimpleModel();
+        expectedItem2.setAge(2);
+        expected.getModelList().add(expectedItem1);
+        expected.getModelList().add(expectedItem2);
+
+        CompositeUnOrderedModel actual = new CompositeUnOrderedModel();
+        actual.setModelList(new ArrayList<>());
+        SimpleModel actualItem1 = new SimpleModel();
+        actualItem1.setAge(1);
+        SimpleModel actualItem2 = new SimpleModel();
+        actualItem2.setAge(2);
+        actual.getModelList().add(actualItem2);
+        actual.getModelList().add(actualItem1);
+
+        assertThat(actual, Entity.isEqualTo(expected));
+    }
+
+    @Test
+    public void childEntityValueListComparisonUnOrdered() {
+        SimpleUnOrderedModel expected = new SimpleUnOrderedModel();
+        expected.setNames(new ArrayList<>());
+        expected.getNames().add("Name1");
+        expected.getNames().add("Name2");
+        expected.getNames().add("Name3");
+
+        SimpleUnOrderedModel actual = new SimpleUnOrderedModel();
+        actual.setNames(new ArrayList<>());
+        actual.getNames().add("Name2");
+        actual.getNames().add("Name3");
+        actual.getNames().add("Name1");
+
+        assertThat(actual, Entity.isEqualTo(expected));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void childEntityListComparisonUnOrdered_failing() {
+        CompositeUnOrderedModel expected = new CompositeUnOrderedModel();
+        expected.setModelList(new ArrayList<>());
+        SimpleModel expectedItem1 = new SimpleModel();
+        expectedItem1.setAge(1);
+        SimpleModel expectedItem2 = new SimpleModel();
+        expectedItem2.setAge(2);
+        expected.getModelList().add(expectedItem1);
+        expected.getModelList().add(expectedItem2);
+
+        CompositeUnOrderedModel actual = new CompositeUnOrderedModel();
+        actual.setModelList(new ArrayList<>());
+        SimpleModel actualItem1 = new SimpleModel();
+        actualItem1.setAge(1);
+        SimpleModel actualItem2 = new SimpleModel();
+        actualItem2.setAge(3);
+        actual.getModelList().add(actualItem2);
+        actual.getModelList().add(actualItem1);
+
+        assertThat(actual, Entity.isEqualTo(expected));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void childEntityValueListComparisonUnOrdered_failing() {
+        SimpleUnOrderedModel expected = new SimpleUnOrderedModel();
+        expected.setNames(new ArrayList<>());
+        expected.getNames().add("Name1");
+        expected.getNames().add("Name2");
+        expected.getNames().add("Name3");
+
+        SimpleUnOrderedModel actual = new SimpleUnOrderedModel();
+        actual.setNames(new ArrayList<>());
+        actual.getNames().add("Name2");
+        actual.getNames().add("Name3");
+        actual.getNames().add("Name4");
+
+        assertThat(actual, Entity.isEqualTo(expected));
+    }
+}

--- a/src/test/java/org/testmonkeys/jentitytest/test/integration/childList/CompositeUnOrderedModel.java
+++ b/src/test/java/org/testmonkeys/jentitytest/test/integration/childList/CompositeUnOrderedModel.java
@@ -1,0 +1,19 @@
+package org.testmonkeys.jentitytest.test.integration.childList;
+
+import org.testmonkeys.jentitytest.framework.ChildEntityListComparison;
+
+import java.util.List;
+
+public class CompositeUnOrderedModel {
+
+    @ChildEntityListComparison(ordered = false)
+    private List<SimpleModel> modelList;
+
+    public List<SimpleModel> getModelList() {
+        return this.modelList;
+    }
+
+    public void setModelList(List<SimpleModel> modelList) {
+        this.modelList = modelList;
+    }
+}

--- a/src/test/java/org/testmonkeys/jentitytest/test/integration/childList/SimpleUnOrderedModel.java
+++ b/src/test/java/org/testmonkeys/jentitytest/test/integration/childList/SimpleUnOrderedModel.java
@@ -1,0 +1,20 @@
+package org.testmonkeys.jentitytest.test.integration.childList;
+
+import org.testmonkeys.jentitytest.framework.ChildEntityListComparison;
+
+import java.util.List;
+
+public class SimpleUnOrderedModel {
+    private List<String> names;
+
+    @ChildEntityListComparison(ordered = false)
+    public List<String> getNames() {
+        return names;
+    }
+
+    public void setNames(List<String> names) {
+        this.names = names;
+    }
+
+
+}


### PR DESCRIPTION
The new option allows for un-ordered list comparisons, with "closest-match" failure reporting. For un-ordered lists - the closest match is calculated on the least amount of mismatches in the element's properties
Closing #71 